### PR TITLE
优化session access log 打印

### DIFF
--- a/session.go
+++ b/session.go
@@ -891,9 +891,13 @@ const (
 
 func (s *session) runlog(realIp string, costTime time.Duration, input, output *socket.Packet, logType int8) {
 	var addr = s.RemoteAddr().String()
-	if realIp != "" && realIp != addr {
-		addr += "(real: " + realIp + ")"
+	if realIp != "" && realIp == addr {
+		realIp = "same"
 	}
+	if realIp == "" {
+		realIp = "-"
+	}
+	addr += "(real:" + realIp + ")"
 	var (
 		costTimeStr string
 		printFunc   = Infof
@@ -903,9 +907,11 @@ func (s *session) runlog(realIp string, costTime time.Duration, input, output *s
 		if costTime >= s.peer.slowCometDuration {
 			costTimeStr += "(slow)"
 			printFunc = Warnf
+		} else {
+			costTimeStr += "(fast)"
 		}
 	} else {
-		costTimeStr = "-"
+		costTimeStr = "(-)"
 	}
 
 	switch logType {


### PR DESCRIPTION
修改的原因：打印出的日志对日志收集和分析工具不够友好，realip和"slow"位置的值时有时无导致正则提取困难。

修改点：
1. 如果没有值则使用-占位;
2. 保证格式相同，如`(fast)`, `(slow)`, `(-)`，正则需要提取的是括号中的值.