### PR TITLE
优化session access log 打印, 保证realip一定有值

### DIFF
--- a/session.go
+++ b/session.go
@@ -895,9 +895,13 @@ func (s *session) runlog(realIp string, costTime time.Duration, input, output *M
 		return
 	}
 	var addr = s.RemoteAddr().String()
-	if realIp != "" && realIp != addr {
-		addr += "(real: " + realIp + ")"
+	if realIp != "" && realIp == addr {
+		realIp = "same"
 	}
+	if realIp == "" {
+		realIp = "-"
+	}
+	addr += "(real:" + realIp + ")"
 	var (
 		costTimeStr string
 		printFunc   = Infof
@@ -910,13 +914,13 @@ func (s *session) runlog(realIp string, costTime time.Duration, input, output *M
 			if GetLoggerLevel() < INFO {
 				return
 			}
-			costTimeStr = costTime.String()
+			costTimeStr = costTime.String() + "(fast)"
 		}
 	} else {
 		if GetLoggerLevel() < INFO {
 			return
 		}
-		costTimeStr = "-"
+		costTimeStr = "(-)"
 	}
 
 	switch logType {


### PR DESCRIPTION
修改的原因：打印出的日志对日志收集和分析工具不够友好，realip和"slow"位置的值时有时无导致正则提取困难。

修改点：

如果没有值则使用-占位;
保证格式相同，如(fast), (slow), (-)，正则需要提取的是括号中的值.